### PR TITLE
New Jenkins link

### DIFF
--- a/swarm/Dockerfile
+++ b/swarm/Dockerfile
@@ -3,7 +3,7 @@ RUN groupadd -g 1000 jenkins_slave
 RUN useradd -d /home/jenkins_slave -s /bin/bash -m jenkins_slave -u 1000 -g jenkins_slave
 RUN echo jenkins_slave:jpass | chpasswd
 RUN apt-get update && apt-get install -y openjdk-7-jre wget unzip
-RUN wget -O /home/jenkins_slave/swarm-client-1.22-jar-with-dependencies.jar http://maven.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/swarm-client/1.22/swarm-client-1.22-jar-with-dependencies.jar
+RUN wget -O /home/jenkins_slave/swarm-client-1.22-jar-with-dependencies.jar http://repo.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/swarm-client/1.22/swarm-client-1.22-jar-with-dependencies.jar
 COPY startup.sh /usr/bin/startup.sh
 RUN chmod +x /usr/bin/startup.sh
 USER jenkins_slave


### PR DESCRIPTION
Looks like http://maven.jenkins-ci.org/ no longer exists and http://repo.jenkins-ci.org/ is the correct url.