### PR TITLE
Update Dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,9 +1,9 @@
-FROM jenkins
+FROM jenkins/jenkins:2.263.1-lts-centos7
 COPY jenkins_plugins.txt /tmp/jenkins_plugins.txt
-RUN /usr/local/bin/plugins.sh /tmp/jenkins_plugins.txt
+RUN xargs /usr/local/bin/install-plugins.sh < /tmp/jenkins_plugins.txt
 USER root
 RUN rm /tmp/jenkins_plugins.txt
 RUN groupadd -g 999 docker
-RUN addgroup -a jenkins docker
+RUN usermod -aG docker jenkins
 USER jenkins
 


### PR DESCRIPTION
In the LTS version, there will be an error when passing parameters to sh. It works now.
The command for adding a user to a group has also been changed. This is for Centos7-8.