### PR TITLE
Update jenkins_plugins.txt

### DIFF
--- a/server/jenkins_plugins.txt
+++ b/server/jenkins_plugins.txt
@@ -1,1 +1,2 @@
 swarm:3.4
+ssh-slaves:1.31.3


### PR DESCRIPTION
Without this plugin, the "Restrict Where Project Can Be Run" parameter will not appear